### PR TITLE
feat: meetings DB + multi-page Gradio UI (list/create/save/playback)

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -85,7 +85,10 @@ def get_meeting(db_path: str, meeting_id: int) -> Optional[Dict[str, Any]]:
     # decode json fields
     for key in ("segments_json", "participants_json", "meta_json"):
         try:
-            data[key] = json.loads(data.get(key) or "{}")[0] if key == "segments_json" else json.loads(data.get(key) or "{}")
-        except Exception:
-            data[key] = {} if key != "segments_json" else []
+            if key == "segments_json":
+                data[key] = json.loads(data.get(key) or "[]")
+            else:
+                data[key] = json.loads(data.get(key) or "{}")
+        except json.JSONDecodeError:
+            data[key] = [] if key == "segments_json" else {}
     return data


### PR DESCRIPTION
This PR adds a lightweight meetings database and extends the Gradio UI with list/create/save/playback flows.

Highlights:
- SQLite DB (`data/meetings.db`) with schema `meetings` (id, name, meeting_date, audio_path, transcript_text, segments_json, participants_json, meta_json, created_at)
- New `src/db.py` with helpers: `init_db`, `create_meeting`, `list_meetings`, `get_meeting`
- Enhanced `src/ui_app.py`:
  - Meetings list page: display saved meetings, open for preview (transcript, audio, meta)
  - Transcribe page: existing functionality + Save form for name/date/participant mapping (SPEAKER_XX -> name)
  - Audio copy to `data/raw/meetings/<timestamp>_original.ext`, fallback to original path on copy failure
- Scripts: `scripts/run_ui.sh` (ensures PYTHONPATH), `scripts/record_local.py`, `scripts/setup_local_whisper.sh`, `scripts/check_whisper.py`

Notes:
- Modal replaced with a visibility-toggled Group for compatibility across Gradio versions.
- API summary integration supported via `OPENAI_API_KEY` or UI input.

Please test locally:
- `./scripts/run_ui.sh` and navigate to local URL.
- Create a new meeting via the Transcribe page, then save with participant mapping.
- Verify the meeting appears in the list and can be opened with audio playback.